### PR TITLE
Added Compressible Assets + Vary Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,27 @@ $encoder = new Middlewares\DeflateEncoder($streamFactory);
 
 ## Common Options
 
-### `withCompressPreg(string $expression)`
+### `contentTypeRegex(string $expression)`
 
 This allows the overring of the default regex used to detect what resources are already compressed. The default detects 
 the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as compressible.
 ```php
 Dispatcher::run([
 	(new Middlewares\DeflateEncoder())
-            ->withCompressablePreg('^/application/pdf$/'),
+            ->contentTypeRegex('/^application\/pdf$/'),
 ]);
 ```
 
+### `contentTypeList(string ...$list)`
+
+This allows the overring of the default regex used to detect what resources are already compressed. This requires that 
+the content type match the list provided.
+```php
+Dispatcher::run([
+	(new Middlewares\DeflateEncoder())
+            ->contentTypeList('text/plain','text/html','text/csv'),
+]);
+```
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $encoder = new Middlewares\DeflateEncoder($streamFactory);
 
 ## Common Options
 
-### `contentTypeRegex(string $expression)`
+### `contentType(string ...$patterns)`
 
 This allows the overring of the default patterns used to detect what resources are already compressed. The default 
 pattern detects the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as 

--- a/README.md
+++ b/README.md
@@ -71,23 +71,17 @@ $encoder = new Middlewares\DeflateEncoder($streamFactory);
 
 ### `contentTypeRegex(string $expression)`
 
-This allows the overring of the default regex used to detect what resources are already compressed. The default detects 
-the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as compressible.
+This allows the overring of the default patterns used to detect what resources are already compressed. The default 
+pattern detects the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as 
+compressible. If the pattern begins with a forward slash `/` it is tested as a regular expression, otherwise its is
+case-insensitive string comparison.
 ```php
 Dispatcher::run([
 	(new Middlewares\DeflateEncoder())
-            ->contentTypeRegex('/^application\/pdf$/'),
-]);
-```
-
-### `contentTypeList(string ...$list)`
-
-This allows the overring of the default regex used to detect what resources are already compressed. This requires that 
-the content type match the list provided.
-```php
-Dispatcher::run([
-	(new Middlewares\DeflateEncoder())
-            ->contentTypeList('text/plain','text/html','text/csv'),
+            ->contentType(
+                    '/^application\/pdf$/', // Regular Expression
+                    'text/csv' // Text Pattern
+            )
 ]);
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ $streamFactory = new MyOwnStreamFactory();
 $encoder = new Middlewares\DeflateEncoder($streamFactory);
 ```
 
+## Common Options
+
+### `withCompressPreg(string $expression)`
+
+This allows the overring of the default regex used to detect what resources are already compressed. The default detects 
+the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as compressible.
+```php
+Dispatcher::run([
+	(new Middlewares\DeflateEncoder())
+            ->withCompressablePreg('^/application/pdf$/'),
+]);
+```
+
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "issues": "https://github.com/middlewares/encoder/issues"
     },
     "require": {
+        "ext-zlib": "*",
         "php": "^7.2",
         "middlewares/utils": "^3.0",
         "psr/http-server-middleware": "^1.0"

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -46,7 +46,6 @@ abstract class Encoder
             }
             return $response
                 ->withHeader('Content-Encoding', $this->encoding)
-                ->withHeader('Content-Length', $stream->getSize())
                 ->withHeader('Vary', implode(',', $vary))
                 ->withBody($stream);
         }

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -24,6 +24,7 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertEquals('gzip', $response->getHeaderLine('Content-Encoding'));
+        $this->assertTrue($response->hasHeader('Vary'));
         $this->assertEquals(gzencode('Hello world'), (string) $response->getBody());
     }
 
@@ -40,7 +41,9 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertEquals('deflate', $response->getHeaderLine('Content-Encoding'));
+        $this->assertTrue($response->hasHeader('Vary'));
         $this->assertEquals(gzdeflate('Hello world'), (string) $response->getBody());
+        $this->assertEquals(strlen(gzdeflate('Hello world')), (int) $response->getHeaderLine('Content-Length'));
     }
 
     public function testNoEncoder()
@@ -56,7 +59,62 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertFalse($response->hasHeader('Content-Encoding'));
-        $this->assertFalse($response->hasHeader('Content-Length'));
-        $this->assertEquals('Hello world', (string) $response->getBody());
+        $body = (string) $response->getBody();
+        $this->assertEquals('Hello world', $body);
+    }
+
+    public function contentTypeList()
+    {
+        return [
+            ['application/zip', '#ZIP', true],
+            ['application/json', '#JSON', false],
+            ['image/gif', '#GIF', true],
+            ['image/jpeg', '#JPEG', true],
+            ['image/png', '#PNG', true],
+            ['image/svg+xml', '#SGV', false],
+            ['image/webp', '#WEBP', true],
+            ['text/csv', '#csv', false],
+            ['text/html', '#HTML', false],
+            ['text/html;charset=UTF-8', '#HTML', false],
+            ['text/xml', '#XML', false],
+        ];
+    }
+
+    /**
+     * @dataProvider contentTypeList
+     * @param mixed $contentType
+     * @param mixed $body
+     * @param mixed $isCompressed
+     */
+    public function testNoDoubleCompress($contentType, $body, $isCompressed)
+    {
+        $request = Factory::createServerRequest('GET', '/')->withHeader('Accept-Encoding', 'gzip,deflate');
+
+        $response = Dispatcher::run([
+            new DeflateEncoder(),
+            new GzipEncoder(),
+            function () use ($contentType, $body) {
+                return self::makeResponse($contentType, $body);
+            },
+        ], $request);
+
+        $this->assertEquals(
+            !$isCompressed,
+            $response->hasHeader('Content-Encoding'),
+            'Content encoding should only be added to non compressed responses'
+        );
+        if ($isCompressed) {
+            $this->assertEquals($body, (string) $response->getBody());
+        } else {
+            $this->assertEquals($body, gzdecode((string) $response->getBody()));
+        }
+    }
+
+    public static function makeResponse($contentType, $body)
+    {
+        $res = Factory::createResponse(200)
+            ->withHeader('Content-Type', $contentType);
+        $res->getBody()->write($body);
+        return $res;
     }
 }

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -24,6 +24,7 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertEquals('gzip', $response->getHeaderLine('Content-Encoding'));
+        $this->assertFalse($response->hasHeader('Content-Length'));
         $this->assertTrue($response->hasHeader('Vary'));
         $this->assertEquals(gzencode('Hello world'), (string) $response->getBody());
     }
@@ -41,9 +42,9 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertEquals('deflate', $response->getHeaderLine('Content-Encoding'));
+        $this->assertFalse($response->hasHeader('Content-Length'));
         $this->assertTrue($response->hasHeader('Vary'));
         $this->assertEquals(gzdeflate('Hello world'), (string) $response->getBody());
-        $this->assertEquals(strlen(gzdeflate('Hello world')), (int) $response->getHeaderLine('Content-Length'));
     }
 
     public function testNoEncoder()
@@ -59,6 +60,7 @@ class EncoderTest extends TestCase
         ], $request);
 
         $this->assertFalse($response->hasHeader('Content-Encoding'));
+        $this->assertFalse($response->hasHeader('Content-Length'));
         $body = (string) $response->getBody();
         $this->assertEquals('Hello world', $body);
     }


### PR DESCRIPTION
Middleware not looks at Content-Type to determine if its worth compressing the response, and also adds a Vary: Content-Encoding if its not already present.