### PR TITLE
Refactor - Multiple Compression/Encoding Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] - 2021-07-14
+
+### Added
+
+- Brotli & ZStd Compression are now support when the correspoding php extensions are avaiable
+
+### Changed
+ 
+- Generic CompressEncoder middleware with with pluggable Compressors now replaces the individual `GzipEncoder` and `DefalteEncoder`.
+
+### Deprecated
+
+- The `GzipEncoder` and the `DeflateEncoder` are now deprecated, as they are
+  just shims for backwards compatibility. Please replace them with `CompressEncoder`
+
+### Removed
+
+- The `Encoder` class has been removed, as its no longer functional.
+
 ## [2.1.1] - 2020-12-03
 ### Added
 - Support for PHP 8.0

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ CompressEncoder middleware.
 ```diff
 Dispatcher::run([
 ...
-- 	new Middlewares\GzipEncoder(),
-- 	new Middlewares\DeflateEncoder(),
-+ 	new Middlewares\CompressEncoder(),
+- 	new \Middlewares\GzipEncoder(),
+- 	new \Middlewares\DeflateEncoder(),
++ 	new \Middlewares\CompressEncoder(),
 ...
 ]);
 ```
@@ -77,7 +77,7 @@ If it's not defined, [Middleware\Utils\Factory](https://github.com/middlewares/u
 ```php
 $streamFactory = new MyOwnStreamFactory();
 
-$encoder = new Middlewares\CompressEncoder($streamFactory);
+$encoder = new \Middlewares\CompressEncoder($streamFactory);
 ```
 
 - You can also provide your own list of Compressors (that implement the `CompressorInterface`). For example:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ CompressEncoder middleware.
 ```diff
 Dispatcher::run([
 ...
-- 	new \Middlewares\GzipEncoder(),
-- 	new \Middlewares\DeflateEncoder(),
-+ 	new \Middlewares\CompressEncoder(),
+- 	new Middlewares\GzipEncoder(),
+- 	new Middlewares\DeflateEncoder(),
++ 	new Middlewares\CompressEncoder(),
 ...
 ]);
 ```
@@ -65,7 +65,7 @@ Content-Type is considered compressible, and there is no `Content-Encoding` head
 
 ```php
 Dispatcher::run([
-	new \Middlewares\CompressEncoder(),
+	new Middlewares\CompressEncoder(),
 ]);
 ```
 
@@ -77,15 +77,15 @@ If it's not defined, [Middleware\Utils\Factory](https://github.com/middlewares/u
 ```php
 $streamFactory = new MyOwnStreamFactory();
 
-$encoder = new \Middlewares\CompressEncoder($streamFactory);
+$encoder = new Middlewares\CompressEncoder($streamFactory);
 ```
 
-- You can also provide your own list of Compressors (that implement the `CompressorInterface`). For example:
+- You can also provide your own list of Compressors (that implement the `Middlewares\CompressorInterface`). For example:
 
 ```php
-$encoder = new \Middlewares\CompressEncoder(null, [
-  new MyProject\LzmaEncoder(),
-  new \Middlewares\GZipEncoder($level = 9),
+$encoder = new Middlewares\CompressEncoder(null, [
+  new MyProject\LzmaCompressor(),
+  new Middlewares\GZipCompressor($level = 9),
 ]);
 
 ```
@@ -100,7 +100,7 @@ its is treated as a case-insensitive string comparison.
 
 ```php
 Dispatcher::run([
-	(new \Middlewares\CompressEncoder())
+	(new Middlewares\CompressEncoder())
             ->contentType(
                     '/^application\/pdf$/', // Regular Expression
                     'text/csv' // Text Pattern
@@ -116,8 +116,8 @@ The brotli compressor is used where the `Accept-Encoding` includes `br` and can 
 level, via a constructor parameter.
 
 ```php
-$encoder = new \Middlewares\CompressEncoder(null, [
-  new \Middlewares\BrotliCompressor($level = 1),
+$encoder = new Middlewares\CompressEncoder(null, [
+  new Middlewares\BrotliCompressor($level = 1),
 ]);
 ```
 ### DeflateCompressor
@@ -126,8 +126,8 @@ The deflate compressor is used where the `Accept-Encoding` includes `deflate` an
 level, via a constructor parameter.
 
 ```php
-$encoder = new \Middlewares\CompressEncoder(null, [
-  new \Middlewares\DeflateCompressor($level = 1),
+$encoder = new Middlewares\CompressEncoder(null, [
+  new Middlewares\DeflateCompressor($level = 1),
 ]);
 ```
 
@@ -137,8 +137,8 @@ The gzip compressor is used where the `Accept-Encoding` includes `gzip` and can 
 level, via a constructor parameter.
 
 ```php
-$encoder = new \Middlewares\CompressEncoder(null, [
-  new \Middlewares\GzipCompressor($level = 1),
+$encoder = new Middlewares\CompressEncoder(null, [
+  new Middlewares\GzipCompressor($level = 1),
 ]);
 ```
 
@@ -148,8 +148,8 @@ The gzip compressor is used where the `Accept-Encoding` includes `zstd` and can 
 level, via a constructor parameter.
 
 ```php
-$encoder = new \Middlewares\CompressEncoder(null, [
-  new \Middlewares\ZStdCompressor($level = 1),
+$encoder = new Middlewares\CompressEncoder(null, [
+  new Middlewares\ZStdCompressor($level = 1),
 ]);
 ```
 
@@ -163,7 +163,7 @@ Compress the response body to GZIP format using [gzencode](http://php.net/manual
 
 ```php
 Dispatcher::run([
-	new \Middlewares\GzipEncoder(),
+	new Middlewares\GzipEncoder(),
 ]);
 ```
 
@@ -179,7 +179,7 @@ Compress the response body to Deflate format using [gzdeflate](http://php.net/ma
 
 ```php
 Dispatcher::run([
-	new \Middlewares\DeflateEncoder(),
+	new Middlewares\DeflateEncoder(),
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,28 @@
 ![Testing][ico-ga]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-Middleware to encode the response body to `gzip` or `deflate` if the `Accept-Encoding` header is present and adds the `Content-Encoding` header. This package is splitted into the following components:
+Middleware to encode the response body using any of `gzip`, `deflate`, `brotli` or `zstd` compression (where available) if the `Accept-Encoding` header is present and can be matched. The `Content-Encoding` header is added when the body has been compressed. This package is split into the following components:
 
-* [GzipEncoder](#gzipencoder)
-* [DeflateEncoder](#deflateencoder)
+* [CompressEncoder](#compressencoder)
+* [BrotliCompressor](#brotlicompressor)
+* [DeflateCompressor](#deflatecompressor)
+* [GzipCompressor](#gzipcompressor)
+* [DeflateCompressor](#deflatecompressor)
+* (deprecated) [GzipEncoder](#gzipencoder-deprecated)
+* (deprecated) [DeflateEncoder](#deflateencoder-deprecated)
 
 You can use the component `ContentEncoding` in the [middlewares/negotiation](https://github.com/middlewares/negotiation#contentencoding) to negotiate the encoding to use.
 
 ## Requirements
 
 * PHP >= 7.2
-* A [PSR-7 http library](https://github.com/middlewares/awesome-psr15-middlewares#psr-7-implementations)
-* A [PSR-15 middleware dispatcher](https://github.com/middlewares/awesome-psr15-middlewares#dispatcher)
+* A [PSR-7 HTTP Library](https://github.com/middlewares/awesome-psr15-middlewares#psr-7-implementations)
+* A [PSR-15 Middleware Dispatcher](https://github.com/middlewares/awesome-psr15-middlewares#dispatcher)
+
+### Optional Requirements
+
+* [PHP Brotli Extension](https://github.com/kjdev/php-ext-brotli)
+* [PHP ZStd Extension](https://github.com/kjdev/php-ext-zstd)
 
 ## Installation
 
@@ -26,7 +36,126 @@ This package is installable and autoloadable via Composer as [middlewares/encode
 composer require middlewares/encoder
 ```
 
-## GzipEncoder
+## Upgrading from v2.x or earlier
+
+When upgrading its advised to switch from using the deprecated GzipEncoder and or DeflateEncoder directly, to using the 
+CompressEncoder middleware.
+
+```diff
+Dispatcher::run([
+...
+- 	new Middlewares\GzipEncoder(),
+- 	new Middlewares\DeflateEncoder(),
++ 	new Middlewares\CompressEncoder(),
+...
+]);
+```
+
+_This configuration will try ZStd, Brotli, GZip, and then Deflate, in that order, if available (php extensions are 
+loaded for zstd and or brotli)._
+
+## CompressEncoder
+
+Compress the response body to matching `Accept-Encoding` format format using the first matching Compressor (by default 
+`zstd`, `brotli`, `gzip` and `defalate` are tried, in that order, where php extentions are available) after which the 
+`Content-Encoding` header will be added to the output.
+
+**Note:** The response body is encoded only if the `Accept-Encoding` header contains an available compression type, the
+Content-Type is considered compressible, and there is no `Content-Encoding` header.
+
+```php
+Dispatcher::run([
+	new \Middlewares\CompressEncoder(),
+]);
+```
+
+#### Optional Parameters:
+
+- You can provide a `Psr\Http\Message\StreamFactoryInterface` that will be used to create the response body. 
+If it's not defined, [Middleware\Utils\Factory](https://github.com/middlewares/utils#factory) will be used a default.
+
+```php
+$streamFactory = new MyOwnStreamFactory();
+
+$encoder = new Middlewares\CompressEncoder($streamFactory);
+```
+
+- You can also provide your own list of Compressors (that implement the `CompressorInterface`). For example:
+
+```php
+$encoder = new \Middlewares\CompressEncoder(null, [
+  new MyProject\LzmaEncoder(),
+  new \Middlewares\GZipEncoder($level = 9),
+]);
+
+```
+
+### Only compress specific Content-Types
+
+This option allows the overriding of the default patterns used to detect what resources are already compressed.
+
+The default pattern detects the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content
+types as compressible. If the pattern begins with a forward slash `/` it is tested as a regular expression, otherwise
+its is treated as a case-insensitive string comparison.
+
+```php
+Dispatcher::run([
+	(new \Middlewares\CompressEncoder())
+            ->contentType(
+                    '/^application\/pdf$/', // Regular Expression
+                    'text/csv' // Text Pattern
+            )
+]);
+```
+
+---
+
+### BrotliCompressor
+
+The brotli compressor is used where the `Accept-Encoding` includes `br` and can be configured with a custom compression 
+level, via a constructor parameter.
+
+```php
+$encoder = new \Middlewares\CompressEncoder(null, [
+  new \Middlewares\BrotliCompressor($level = 1),
+]);
+```
+### DeflateCompressor
+
+The deflate compressor is used where the `Accept-Encoding` includes `deflate` and can be configured with a custom compression 
+level, via a constructor parameter.
+
+```php
+$encoder = new \Middlewares\CompressEncoder(null, [
+  new \Middlewares\DeflateCompressor($level = 1),
+]);
+```
+
+### GzipCompressor
+
+The gzip compressor is used where the `Accept-Encoding` includes `gzip` and can be configured with a custom compression 
+level, via a constructor parameter.
+
+```php
+$encoder = new \Middlewares\CompressEncoder(null, [
+  new \Middlewares\GzipCompressor($level = 1),
+]);
+```
+
+### ZStdCompressor
+
+The gzip compressor is used where the `Accept-Encoding` includes `zstd` and can be configured with a custom compression 
+level, via a constructor parameter.
+
+```php
+$encoder = new \Middlewares\CompressEncoder(null, [
+  new \Middlewares\ZStdCompressor($level = 1),
+]);
+```
+
+## GzipEncoder (deprecated)
+
+**Please note, this is provided for backward compatibility only**
 
 Compress the response body to GZIP format using [gzencode](http://php.net/manual/en/function.gzencode.php) and add the header `Content-Encoding: gzip`.
 
@@ -34,19 +163,15 @@ Compress the response body to GZIP format using [gzencode](http://php.net/manual
 
 ```php
 Dispatcher::run([
-	new Middlewares\GzipEncoder(),
+	new \Middlewares\GzipEncoder(),
 ]);
 ```
 
-Optionally, you can provide a `Psr\Http\Message\StreamFactoryInterface` that will be used to create the response body. If it's not defined, [Middleware\Utils\Factory](https://github.com/middlewares/utils#factory) will be used to detect it automatically.
+Optionally, you can provide a `Psr\Http\Message\StreamFactoryInterface` as above. 
 
-```php
-$streamFactory = new MyOwnStreamFactory();
+## DeflateEncoder (deprecated)
 
-$encoder = new Middlewares\GzipEncoder($streamFactory);
-```
-
-## DeflateEncoder
+**Please note, this is provided for backward compatibility only**
 
 Compress the response body to Deflate format using [gzdeflate](http://php.net/manual/en/function.gzdeflate.php) and add the header `Content-Encoding: deflate`.
 
@@ -54,35 +179,12 @@ Compress the response body to Deflate format using [gzdeflate](http://php.net/ma
 
 ```php
 Dispatcher::run([
-	new Middlewares\DeflateEncoder(),
+	new \Middlewares\DeflateEncoder(),
 ]);
 ```
 
-Optionally, you can provide a `Psr\Http\Message\StreamFactoryInterface` that will be used to create the response body. If it's not defined, [Middleware\Utils\Factory](https://github.com/middlewares/utils#factory) will be used to detect it automatically.
+Optionally, you can provide a `Psr\Http\Message\StreamFactoryInterface` as above.
 
-```php
-$streamFactory = new MyOwnStreamFactory();
-
-$encoder = new Middlewares\DeflateEncoder($streamFactory);
-```
-
-## Common Options
-
-### contentType
-
-This option allows the overring of the default patterns used to detect what resources are already compressed.
-
-The default pattern detects the following mime types `text/*`, `application/json`, `image/svg+xml` and empty content types as compressible. If the pattern begins with a forward slash `/` it is tested as a regular expression, otherwise its is case-insensitive string comparison.
-
-```php
-Dispatcher::run([
-	(new Middlewares\DeflateEncoder())
-            ->contentType(
-                    '/^application\/pdf$/', // Regular Expression
-                    'text/csv' // Text Pattern
-            )
-]);
-```
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "friendsofphp/php-cs-fixer": "^2.0",
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^0.12",
+        "vimeo/psalm": "^4.8"
     },
     "suggest": {
         "ext-brotli": "Enable Brotli Compression",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
         "oscarotero/php-cs-fixer-config": "^1.0",
         "phpstan/phpstan": "^0.12"
     },
+    "suggest": {
+        "ext-brotli": "Enable Brotli Compression",
+        "ext-zstd": "Enable ZStd Compression"
+    },
     "autoload": {
         "psr-4": {
             "Middlewares\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "ext-zlib": "*",
         "php": "^7.2 || ^8.0",
-        "middlewares/utils": "^3.0",
+        "middlewares/utils": "^4.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -25,6 +25,10 @@ final class BrotliCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        return brotli_compress($input, $this->level);
+        $out = brotli_compress($input, $this->level);
+        if($out === false) {
+            throw new \RuntimeException('Error occurred while compressing output');
+        }
+        return $out;
     }
 }

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -11,9 +11,9 @@ final class BrotliCompressor implements CompressorInterface
      * Brotli Compression Support (requires brotli php extension)
      *
      * @link https://github.com/kjdev/php-ext-brotli
-     * @param int $level Brotli Compression Level, 11 is default
+     * @param int $level Brotli Compression Level, 5 is default (small than gzip, about as fast)
      */
-    public function __construct(int $level = 11)
+    public function __construct(int $level = 5)
     {
         $this->level = $level;
     }

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -25,7 +25,7 @@ final class BrotliCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        $out = brotli_compress($input, $this->level);
+        $out = \brotli_compress($input, $this->level);
         if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Middlewares;
+
+final class BrotliCompressor implements CompressorInterface
+{
+    /** @var int Compression Level */
+    private $level;
+
+    /**
+     * Brotli Compression Support (requires brotli php extension)
+     *
+     * @link https://github.com/kjdev/php-ext-brotli
+     * @param int $level Brotli Compression Level, 11 is default
+     */
+    public function __construct(int $level = 11)
+    {
+        $this->level = $level;
+    }
+
+    public function name(): string
+    {
+        return 'br';
+    }
+
+    public function compress(string $input): string
+    {
+        return brotli_compress($input, $this->level);
+    }
+}

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -26,7 +26,7 @@ final class BrotliCompressor implements CompressorInterface
     public function compress(string $input): string
     {
         $out = brotli_compress($input, $this->level);
-        if($out === false) {
+        if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }
         return $out;

--- a/src/BrotliCompressor.php
+++ b/src/BrotliCompressor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Middlewares;
 

--- a/src/CompressEncoder.php
+++ b/src/CompressEncoder.php
@@ -13,11 +13,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 class CompressEncoder
 {
     /**
-     * @var string
-     */
-    protected $encoding;
-
-    /**
      * @var StreamFactoryInterface
      */
     protected $streamFactory;

--- a/src/CompressEncoder.php
+++ b/src/CompressEncoder.php
@@ -117,6 +117,7 @@ class CompressEncoder
             $o[] = new BrotliCompressor();
         }
         $o[] = new GzipCompressor();
+        $o[] = new DeflateCompressor();
         return $o;
     }
 }

--- a/src/CompressEncoder.php
+++ b/src/CompressEncoder.php
@@ -51,9 +51,8 @@ class CompressEncoder
         $response = $handler->handle($request);
 
         $compressor = $this->getCompressor($request);
-        if (
-            !$response->hasHeader('Content-Encoding')
-            && $compressor
+        if ($compressor
+            && !$response->hasHeader('Content-Encoding')
             && $this->isCompressible($response)
         ) {
             $stream = $this->streamFactory->createStream($compressor->compress((string) $response->getBody()));

--- a/src/CompressorInterface.php
+++ b/src/CompressorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Middlewares;
+
+interface CompressorInterface
+{
+    /**
+     * Return the name of the compression/encoding scheme, eg gzip, deflate
+     *
+     * @return string
+     */
+    public function name(): string;
+
+    /**
+     * Compress the data
+     *
+     * @param  string $input
+     * @return string
+     */
+    public function compress(string $input): string;
+}

--- a/src/CompressorInterface.php
+++ b/src/CompressorInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Middlewares;
 

--- a/src/DeflateCompressor.php
+++ b/src/DeflateCompressor.php
@@ -24,6 +24,10 @@ final class DeflateCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        return gzdeflate($input, $this->level);
+        $out = gzdeflate($input, $this->level);
+        if($out === false) {
+            throw new \RuntimeException('Error occurred while compressing output');
+        }
+        return $out;
     }
 }

--- a/src/DeflateCompressor.php
+++ b/src/DeflateCompressor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Middlewares;
+
+final class DeflateCompressor implements CompressorInterface
+{
+    /** @var int Compression Level */
+    private $level;
+
+    /**
+     * Deflate Compression
+     *
+     * @param int $level Compression Level, -1 for default compression level
+     */
+    public function __construct(int $level = -1)
+    {
+        $this->level = $level;
+    }
+
+    public function name(): string
+    {
+        return 'deflate';
+    }
+
+    public function compress(string $input): string
+    {
+        return gzdeflate($input, $this->level);
+    }
+}

--- a/src/DeflateCompressor.php
+++ b/src/DeflateCompressor.php
@@ -25,7 +25,7 @@ final class DeflateCompressor implements CompressorInterface
     public function compress(string $input): string
     {
         $out = gzdeflate($input, $this->level);
-        if($out === false) {
+        if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }
         return $out;

--- a/src/DeflateCompressor.php
+++ b/src/DeflateCompressor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Middlewares;
 

--- a/src/DeflateEncoder.php
+++ b/src/DeflateEncoder.php
@@ -6,6 +6,9 @@ namespace Middlewares;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
+/***
+ * @deprecated Replace with CompressEncoder
+ */
 class DeflateEncoder extends CompressEncoder implements MiddlewareInterface
 {
     public function __construct(StreamFactoryInterface $streamFactory = null)

--- a/src/DeflateEncoder.php
+++ b/src/DeflateEncoder.php
@@ -3,20 +3,13 @@ declare(strict_types = 1);
 
 namespace Middlewares;
 
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
-class DeflateEncoder extends Encoder implements MiddlewareInterface
+class DeflateEncoder extends CompressEncoder implements MiddlewareInterface
 {
-    /**
-     * @var string
-     */
-    protected $encoding = 'deflate';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function encode(string $content): string
+    public function __construct(StreamFactoryInterface $streamFactory = null)
     {
-        return (string) gzdeflate($content);
+        parent::__construct($streamFactory, [new DeflateCompressor()]);
     }
 }

--- a/src/GzipCompressor.php
+++ b/src/GzipCompressor.php
@@ -24,6 +24,10 @@ final class GzipCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        return gzencode($input, $this->level);
+        $out = gzencode($input, $this->level);
+        if($out === false) {
+            throw new \RuntimeException('Error occurred while compressing output');
+        }
+        return $out;
     }
 }

--- a/src/GzipCompressor.php
+++ b/src/GzipCompressor.php
@@ -25,7 +25,7 @@ final class GzipCompressor implements CompressorInterface
     public function compress(string $input): string
     {
         $out = gzencode($input, $this->level);
-        if($out === false) {
+        if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }
         return $out;

--- a/src/GzipCompressor.php
+++ b/src/GzipCompressor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Middlewares;
+
+final class GzipCompressor implements CompressorInterface
+{
+    /** @var int Compression Level */
+    private $level;
+
+    /**
+     * GZIP Compression
+     *
+     * @param int $level GZIP Level, -1 for default compression level
+     */
+    public function __construct(int $level = -1)
+    {
+        $this->level = $level;
+    }
+
+    public function name(): string
+    {
+        return 'gzip';
+    }
+
+    public function compress(string $input): string
+    {
+        return gzencode($input, $this->level);
+    }
+}

--- a/src/GzipCompressor.php
+++ b/src/GzipCompressor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Middlewares;
 

--- a/src/GzipEncoder.php
+++ b/src/GzipEncoder.php
@@ -3,20 +3,13 @@ declare(strict_types = 1);
 
 namespace Middlewares;
 
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
-class GzipEncoder extends Encoder implements MiddlewareInterface
+class GzipEncoder extends CompressEncoder implements MiddlewareInterface
 {
-    /**
-     * @var string
-     */
-    protected $encoding = 'gzip';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function encode(string $content): string
+    public function __construct(StreamFactoryInterface $streamFactory = null)
     {
-        return (string) gzencode($content);
+        parent::__construct($streamFactory, [new GzipCompressor()]);
     }
 }

--- a/src/GzipEncoder.php
+++ b/src/GzipEncoder.php
@@ -6,6 +6,10 @@ namespace Middlewares;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
+/***
+ * @deprecated Replace with CompressEncoder
+ */
+
 class GzipEncoder extends CompressEncoder implements MiddlewareInterface
 {
     public function __construct(StreamFactoryInterface $streamFactory = null)

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -14,7 +14,7 @@ final class ZStdCompressor implements CompressorInterface
      * @link https://github.com/kjdev/php-ext-zstd
      * @param int $level ZStd Compression Level
      */
-    public function __construct(int $level = \ZSTD_COMPRESS_LEVEL_DEFAULT)
+    public function __construct(int $level = 9)
     {
         $this->level = $level;
     }

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -13,7 +13,7 @@ final class ZStdCompressor implements CompressorInterface
      * @link https://github.com/kjdev/php-ext-zstd
      * @param int $level ZStd Compression Level
      */
-    public function __construct(int $level = ZSTD_COMPRESS_LEVEL_DEFAULT)
+    public function __construct(int $level = \ZSTD_COMPRESS_LEVEL_DEFAULT)
     {
         $this->level = $level;
     }
@@ -25,7 +25,7 @@ final class ZStdCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        $out = zstd_compress($input, $this->level);
+        $out = \zstd_compress($input, $this->level);
         if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Middlewares;
+
+final class ZStdCompressor implements CompressorInterface
+{
+    /** @var int Compression Level */
+    private $level;
+
+    /**
+     * ZStd Compression Support (requires zstd php extension)
+     *
+     * @link https://github.com/kjdev/php-ext-zstd
+     * @param int $level ZStd Compression Level
+     */
+    public function __construct(int $level = ZSTD_COMPRESS_LEVEL_DEFAULT)
+    {
+        $this->level = $level;
+    }
+
+    public function name(): string
+    {
+        return 'zstd';
+    }
+
+    public function compress(string $input): string
+    {
+        return zstd_compress($input, $this->level);
+    }
+}

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -25,6 +25,10 @@ final class ZStdCompressor implements CompressorInterface
 
     public function compress(string $input): string
     {
-        return zstd_compress($input, $this->level);
+        $out = zstd_compress($input, $this->level);
+        if($out === false) {
+            throw new \RuntimeException('Error occurred while compressing output');
+        }
+        return $out;
     }
 }

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -26,7 +26,7 @@ final class ZStdCompressor implements CompressorInterface
     public function compress(string $input): string
     {
         $out = zstd_compress($input, $this->level);
-        if($out === false) {
+        if ($out === false) {
             throw new \RuntimeException('Error occurred while compressing output');
         }
         return $out;

--- a/src/ZStdCompressor.php
+++ b/src/ZStdCompressor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Middlewares;
 

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -123,7 +123,6 @@ class EncoderTest extends TestCase
                 return self::makeResponse('text/html', 'html');
             },
         ], $request);
-
         $this->assertEquals(
             true,
             $response->hasHeader('Content-Encoding'),


### PR DESCRIPTION
Refactored CompressEncoder to support multiple methods in a single middleware, with backward compact

- Single Middleware for compression, that out of the box configures itself based on what PHP extensions are available (zstd, or brotli)
- Orderable based on compression preference if required
- Individual compression methods can have their compression level adjusted where required.

To do:
- [x] Update Documentation
- [ ] Setup testing with zstd and brotli extensions loaded
- [x] Write an upgrade guide going from version 2.x to 3.x
- [ ] Fix/workaround PHP Stan warnings about `brotli_compress`
- [x] Add deprecation PHPDOC to GzipEncoder and Deflate Encoder classes
- [ ] Add unit tests for multiple compressor logic